### PR TITLE
Gen senders

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,29 +147,32 @@ All data, for both inputs and outputs, is sent over network sockets by implement
 <a id="bisenders"></a>
 ##### Built-in senders
 
-Senders have already been implemented for twelve types:
+Senders have already been implemented for all primitive types and Strings, as well as arrays of those types, and matrices (nested arrays) of those types. They are named in the format `<type>Sender`, `<type>ArraySender`, or `<type>MatrixSender`
 
-Type | Constructor(s)
-:---:|:---:
-`Boolean` | `BooleanSender()`
-`Integer` | `IntSender()`
-`Double` | `DoubleSender()`
-`String` | `StringSender()`
-`boolean[]` | `BooleanArraySender()`<br/>`BooleanArraySender(int length)`
-`int[]` | `IntArraySender()`<br/>`IntArraySender(int length)`
-`double[]` | `DoubleArraySender()`<br/>`DoubleArraySender(int length)`
-`String[]` | `StringArraySender()`<br/>`StringArraySender(int length)`
-`boolean[][]` | `BooleanMatrixSender()`<br/>`BooleanMatrixSender(int width, int height)`
-`int[][]` | `IntMatrixSender()`<br/>`IntMatrixSender(int width, int height)`
-`double[][]` | `DoubleMatrixSender()`<br/>`DoubleMatrixSender(int width, int height)`
-`String[][]` | `StringMatrixSender()`<br/>`StringMatrixSender(int width, int height)`
+The Array/Matrix senders allow you to optionally specify the dimensions of the array/matrix in the constructor, *as long as the dimensions are constant*. If you do not specify the dimensions, you are allowed to send arrays/matrices of varying sizes, at the cost of slightly more network overhead (negligible for arrays/matrices with more than a few elements). If you *do* specify the dimensions, attempting to send an array of a different size is undefined behavior and may *or may not* result in an error. When in doubt, just don't specify the length.
 
-The Array/Matrix senders allow you to specify the dimensions of the array/matrix,
-*as long as the dimensions are constant*. If you do not specify the dimensions,
-you are allowed to send arrays/matrices of varying sizes, at the cost of slightly more network
-overhead (negligible for arrays/matrices with more than a few elements). If you *do* specify the dimensions,
-attempting to send an array of a different size is undefined behavior and may *or may not* result in an error.
-When in doubt, just don't specify the length.
+Examples:
+
+```java
+// Sends single chars at a time
+CharSender s1 = new CharSender();
+
+// Sends double[] of any size
+DoubleArraySender s2 = new DoubleArraySender();
+
+// Sends String[] of *EXACTLY* five elements
+StringArraySender s3 = new StringArraySender(5);
+
+// Sends long[][] of any size
+LongMatrixSender s4 = new LongMatrixSender();
+
+// Sends int[][] that are *EXACTLY* 3x4 in size (i.e. int[3][4])
+IntMatrixSender s5 = new IntMatrixSender(3, 4);
+```
+
+Currently you aren't able to specify only one dimension for matrix senders (either both or neither).
+
+The source code of the senders was generated from templates, because Java doesn't let you use primitive types as generic type arguments. See `src/gen/README.md` for details on changing the source or adding more built-in senders.
 
 <a id="csenders"></a>
 ##### Custom Senders

--- a/src/bench/kotlin/parspiceBench/workers/GfposcWorker.kt
+++ b/src/bench/kotlin/parspiceBench/workers/GfposcWorker.kt
@@ -1,7 +1,6 @@
 package parspiceBench.workers
 
 import parspice.sender.DoubleArraySender
-import parspice.sender.IntSender
 import parspiceBench.BenchWorker
 import spice.basic.CSPICE.*
 

--- a/src/bench/kotlin/parspiceBench/workers/SquareWorker.kt
+++ b/src/bench/kotlin/parspiceBench/workers/SquareWorker.kt
@@ -1,7 +1,6 @@
 package parspiceBench.workers
 
 import parspice.sender.DoubleSender
-import parspice.worker.OWorker
 import parspiceBench.BenchWorker
 import kotlin.math.pow
 

--- a/src/gen/README.md
+++ b/src/gen/README.md
@@ -1,6 +1,6 @@
-# Pre-built Sender Generation
+# Built-in Sender Generation
 
-Java doesn't allow you to use primitive types as generic arguments (which is *so spectacularly frustrating*), so in order to provide the user with pre-built senders for primitives, primitive arrays, and primitive matrices, *all* of them have to be hardcoded.
+Java doesn't allow you to use primitive types as generic arguments (which is *so spectacularly frustrating*), so in order to provide the user with built-in senders for primitives, primitive arrays, and primitive matrices, *all* of them have to be hardcoded.
 
 They all have very similar code that cannot be consolidated *at all* (seriously, the ArraySenders and MatrixSenders cannot even have a common superclass with a generic argument because that would require the argument to be a primitive), so we are generating the source instead. Since the generated source is unlikely to change, we are including the output in the repo instead of forcing users to generate it on build (which would a python3 dependency on PyYAML).
 

--- a/src/gen/README.md
+++ b/src/gen/README.md
@@ -1,0 +1,54 @@
+# Pre-built Sender Generation
+
+Java doesn't allow you to use primitive types as generic arguments (which is *so spectacularly frustrating*), so in order to provide the user with pre-built senders for primitives, primitive arrays, and primitive matrices, all of them have to be hardcoded.
+
+Since they all have very similar code that cannot be consolidated *at all* (seriously, the ArraySenders and MatrixSenders cannot even have a common superclass with a generic argument because that would require the argument to be a primitive), we are generating the source instead. Since the generated source is unlikely to change, we are including the output in the repo instead of forcing users to generate it on build.
+
+But if the source does need to change, that's what this is for.
+
+## Configuration
+
+The `yaml/senders.yaml` file has the configuration for generating all of the sender implementations. It is an array of objects of the following format:
+
+```yaml
+- name: Name to prepend to class name
+  types:
+    - data type for bare sender
+    - data type for array sender
+    - data type for matrix sender
+  stream: function name to append to `ois.read` and `oos.write`
+```
+
+For example:
+
+```yaml
+- name: Int
+  types:
+    - Integer
+    - int
+    - int
+  stream: Int
+- name: String
+  types:
+    - String
+    - String
+    - String
+  stream: UTF
+```
+
+## Templates
+
+The template source files can be found in `src/gen/java/parspice/sender`. They have template arguments like `###NAME###`, `###TYPE###`, and `###STREAM###` that get searched-and-replaced with the values from the yaml file.
+
+## Re-generating
+
+If you make changes to the senders.yaml list, or to the template sources, just re-generate them. You'll need the PyYAML python3 library installed.
+
+```bash
+> cd src/gen/python3
+> python3 generate_senders.py
+```
+
+You'll then have to add the generated files to git of course.
+
+The file paths in the script use forward slashes, so it might not work on Windows. Honestly I don't think it's a big deal because no one is likely ever going to read this entire file. If I'm wrong, hi!

--- a/src/gen/README.md
+++ b/src/gen/README.md
@@ -1,8 +1,8 @@
 # Pre-built Sender Generation
 
-Java doesn't allow you to use primitive types as generic arguments (which is *so spectacularly frustrating*), so in order to provide the user with pre-built senders for primitives, primitive arrays, and primitive matrices, all of them have to be hardcoded.
+Java doesn't allow you to use primitive types as generic arguments (which is *so spectacularly frustrating*), so in order to provide the user with pre-built senders for primitives, primitive arrays, and primitive matrices, *all* of them have to be hardcoded.
 
-Since they all have very similar code that cannot be consolidated *at all* (seriously, the ArraySenders and MatrixSenders cannot even have a common superclass with a generic argument because that would require the argument to be a primitive), we are generating the source instead. Since the generated source is unlikely to change, we are including the output in the repo instead of forcing users to generate it on build.
+They all have very similar code that cannot be consolidated *at all* (seriously, the ArraySenders and MatrixSenders cannot even have a common superclass with a generic argument because that would require the argument to be a primitive), so we are generating the source instead. Since the generated source is unlikely to change, we are including the output in the repo instead of forcing users to generate it on build (which would a python3 dependency on PyYAML).
 
 But if the source does need to change, that's what this is for.
 

--- a/src/gen/java/parspice/sender/TypeArraySender.java
+++ b/src/gen/java/parspice/sender/TypeArraySender.java
@@ -1,0 +1,59 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for ###TYPE###[].
+ *
+ * Accepts arrays of fixed length or dynamic length. If fixed length, the length should
+ * be declared on initialization. If the length is declared, then using arrays of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic arrays, it first sends the length of the array, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class ###NAME###ArraySender implements Sender<###TYPE###[]> {
+    private final int length;
+
+    /**
+     * Creates an instance of ###NAME###ArraySender for dynamic length arrays.
+     */
+    public ###NAME###ArraySender() {
+        this.length = -1;
+    }
+
+    /**
+     * Creates an instance of ###NAME###ArraySender for fixed length arrays.
+     *
+     * @param length the length of all arrays to be serialized an deserialized
+     */
+    public ###NAME###ArraySender(int length) {
+        this.length = length;
+    }
+
+    @Override
+    public ###TYPE###[] read(ObjectInputStream ois) throws IOException {
+        int localLength = length;
+        if (length == -1) {
+            localLength = ois.readInt();
+        }
+        ###TYPE###[] in = new ###TYPE###[localLength];
+        for (int i = 0; i < localLength; i++) {
+            in[i] = ois.read###STREAM###();
+        }
+        return in;
+    }
+
+    @Override
+    public void write(###TYPE###[] out, ObjectOutputStream oos) throws IOException {
+        if (length == -1) {
+            oos.writeInt(out.length);
+        }
+        for (###TYPE### b : out) {
+            oos.write###STREAM###(b);
+        }
+    }
+}

--- a/src/gen/java/parspice/sender/TypeArraySender.java
+++ b/src/gen/java/parspice/sender/TypeArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/gen/java/parspice/sender/TypeMatrixSender.java
+++ b/src/gen/java/parspice/sender/TypeMatrixSender.java
@@ -1,0 +1,67 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for ###TYPE###[][].
+ *
+ * Accepts matrices of fixed dimensions or dynamic dimensions. If fixed dims, the size should
+ * be declared on initialization. If the size is declared, then using matrices of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic matrices, it first sends the dimensions of the matrix, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class ###NAME###MatrixSender implements Sender<###TYPE###[][]> {
+    private final int rows;
+    private final int columns;
+
+    public ###NAME###MatrixSender() {
+        rows = -1;
+        columns = -1;
+    }
+
+    /**
+     * Creates an instance of ###NAME###Matrix.
+     *
+     * @param rows the number of rows (first dimension) of the matrix.
+     * @param columns the number of columns (second dimension) of the matrix.
+     */
+    public ###NAME###MatrixSender(int rows, int columns) {
+        this.rows = rows;
+        this.columns = columns;
+    }
+
+    @Override
+    public ###TYPE###[][] read(ObjectInputStream ois) throws IOException {
+        int localRows = rows;
+        int localColumns = columns;
+        if (rows == -1) {
+            localRows = ois.readInt();
+            localColumns = ois.readInt();
+        }
+        ###TYPE###[][] in = new ###TYPE###[localRows][localColumns];
+        for (int i = 0; i < localRows; i++) {
+            for (int j = 0; j < localColumns; j++) {
+                in[i][j] = ois.read###STREAM###();
+            }
+        }
+        return in;
+    }
+
+    @Override
+    public void write(###TYPE###[][] out, ObjectOutputStream oos) throws IOException {
+        if (rows == -1) {
+            oos.writeInt(out.length);
+            oos.writeInt(out[0].length);
+        }
+        for (###TYPE###[] row : out) {
+            for (###TYPE### b : row) {
+                oos.write###STREAM###(b);
+            }
+        }
+    }
+}

--- a/src/gen/java/parspice/sender/TypeMatrixSender.java
+++ b/src/gen/java/parspice/sender/TypeMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/gen/java/parspice/sender/TypeSender.java
+++ b/src/gen/java/parspice/sender/TypeSender.java
@@ -1,0 +1,20 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for ###TYPE###.
+ */
+public class ###NAME###Sender implements Sender<###TYPE###> {
+    @Override
+    public ###TYPE### read(ObjectInputStream ois) throws IOException {
+        return ois.read###STREAM###();
+    }
+
+    @Override
+    public void write(###TYPE### out, ObjectOutputStream oos) throws IOException {
+        oos.write###STREAM###(out);
+    }
+}

--- a/src/gen/java/parspice/sender/TypeSender.java
+++ b/src/gen/java/parspice/sender/TypeSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/gen/python3/generate_senders.py
+++ b/src/gen/python3/generate_senders.py
@@ -1,0 +1,21 @@
+import yaml
+
+templates = ['TypeSender.java', 'TypeArraySender.java', 'TypeMatrixSender.java']
+template_dir = '../java/parspice/sender/'
+
+outputs = ['Sender.java', 'ArraySender.java', 'MatrixSender.java']
+output_dir = '../../main/java/parspice/sender/'
+
+with open('../yaml/senders.yaml') as senders_file:
+    # use safe_load instead load
+    senders = yaml.safe_load(senders_file)
+
+    for group in senders:
+        for depth in range(3):
+            with open(template_dir + templates[depth]) as template_file:
+                template = template_file.read()
+                output = template.replace("###NAME###", group['name']) \
+                    .replace("###TYPE###", group['types'][depth]) \
+                    .replace("###STREAM###", group['stream'])
+                with open(output_dir + group['name'] + outputs[depth], 'w') as output_file:
+                    output_file.write(output)

--- a/src/gen/yaml/senders.yaml
+++ b/src/gen/yaml/senders.yaml
@@ -1,0 +1,56 @@
+# List of Sender types to generate from
+
+- name: Int
+  types:
+    - Integer
+    - int
+    - int
+  stream: Int
+- name: Boolean
+  types:
+    - Boolean
+    - boolean
+    - boolean
+  stream: Boolean
+- name: Double
+  types:
+    - Double
+    - double
+    - double
+  stream: Double
+- name: String
+  types:
+    - String
+    - String
+    - String
+  stream: UTF
+- name: Short
+  types:
+    - Short
+    - short
+    - short
+  stream: Short
+- name: Long
+  types:
+    - Long
+    - long
+    - long
+  stream: Long
+- name: Float
+  types:
+    - Float
+    - float
+    - float
+  stream: Float
+- name: Char
+  types:
+    - Character
+    - char
+    - char
+  stream: Char
+- name: Byte
+  types:
+    - Byte
+    - byte
+    - byte
+  stream: Byte

--- a/src/main/java/parspice/sender/BooleanArraySender.java
+++ b/src/main/java/parspice/sender/BooleanArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/BooleanMatrixSender.java
+++ b/src/main/java/parspice/sender/BooleanMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/BooleanSender.java
+++ b/src/main/java/parspice/sender/BooleanSender.java
@@ -5,7 +5,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 /**
- * Sender implementation for boolean.
+ * Sender implementation for Boolean.
  */
 public class BooleanSender implements Sender<Boolean> {
     @Override

--- a/src/main/java/parspice/sender/BooleanSender.java
+++ b/src/main/java/parspice/sender/BooleanSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/ByteArraySender.java
+++ b/src/main/java/parspice/sender/ByteArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/ByteArraySender.java
+++ b/src/main/java/parspice/sender/ByteArraySender.java
@@ -1,0 +1,59 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for byte[].
+ *
+ * Accepts arrays of fixed length or dynamic length. If fixed length, the length should
+ * be declared on initialization. If the length is declared, then using arrays of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic arrays, it first sends the length of the array, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class ByteArraySender implements Sender<byte[]> {
+    private final int length;
+
+    /**
+     * Creates an instance of ByteArraySender for dynamic length arrays.
+     */
+    public ByteArraySender() {
+        this.length = -1;
+    }
+
+    /**
+     * Creates an instance of ByteArraySender for fixed length arrays.
+     *
+     * @param length the length of all arrays to be serialized an deserialized
+     */
+    public ByteArraySender(int length) {
+        this.length = length;
+    }
+
+    @Override
+    public byte[] read(ObjectInputStream ois) throws IOException {
+        int localLength = length;
+        if (length == -1) {
+            localLength = ois.readInt();
+        }
+        byte[] in = new byte[localLength];
+        for (int i = 0; i < localLength; i++) {
+            in[i] = ois.readByte();
+        }
+        return in;
+    }
+
+    @Override
+    public void write(byte[] out, ObjectOutputStream oos) throws IOException {
+        if (length == -1) {
+            oos.writeInt(out.length);
+        }
+        for (byte b : out) {
+            oos.writeByte(b);
+        }
+    }
+}

--- a/src/main/java/parspice/sender/ByteMatrixSender.java
+++ b/src/main/java/parspice/sender/ByteMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/ByteMatrixSender.java
+++ b/src/main/java/parspice/sender/ByteMatrixSender.java
@@ -1,0 +1,67 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for byte[][].
+ *
+ * Accepts matrices of fixed dimensions or dynamic dimensions. If fixed dims, the size should
+ * be declared on initialization. If the size is declared, then using matrices of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic matrices, it first sends the dimensions of the matrix, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class ByteMatrixSender implements Sender<byte[][]> {
+    private final int rows;
+    private final int columns;
+
+    public ByteMatrixSender() {
+        rows = -1;
+        columns = -1;
+    }
+
+    /**
+     * Creates an instance of ByteMatrix.
+     *
+     * @param rows the number of rows (first dimension) of the matrix.
+     * @param columns the number of columns (second dimension) of the matrix.
+     */
+    public ByteMatrixSender(int rows, int columns) {
+        this.rows = rows;
+        this.columns = columns;
+    }
+
+    @Override
+    public byte[][] read(ObjectInputStream ois) throws IOException {
+        int localRows = rows;
+        int localColumns = columns;
+        if (rows == -1) {
+            localRows = ois.readInt();
+            localColumns = ois.readInt();
+        }
+        byte[][] in = new byte[localRows][localColumns];
+        for (int i = 0; i < localRows; i++) {
+            for (int j = 0; j < localColumns; j++) {
+                in[i][j] = ois.readByte();
+            }
+        }
+        return in;
+    }
+
+    @Override
+    public void write(byte[][] out, ObjectOutputStream oos) throws IOException {
+        if (rows == -1) {
+            oos.writeInt(out.length);
+            oos.writeInt(out[0].length);
+        }
+        for (byte[] row : out) {
+            for (byte b : row) {
+                oos.writeByte(b);
+            }
+        }
+    }
+}

--- a/src/main/java/parspice/sender/ByteSender.java
+++ b/src/main/java/parspice/sender/ByteSender.java
@@ -1,0 +1,20 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for Byte.
+ */
+public class ByteSender implements Sender<Byte> {
+    @Override
+    public Byte read(ObjectInputStream ois) throws IOException {
+        return ois.readByte();
+    }
+
+    @Override
+    public void write(Byte out, ObjectOutputStream oos) throws IOException {
+        oos.writeByte(out);
+    }
+}

--- a/src/main/java/parspice/sender/ByteSender.java
+++ b/src/main/java/parspice/sender/ByteSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/CharArraySender.java
+++ b/src/main/java/parspice/sender/CharArraySender.java
@@ -1,0 +1,59 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for char[].
+ *
+ * Accepts arrays of fixed length or dynamic length. If fixed length, the length should
+ * be declared on initialization. If the length is declared, then using arrays of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic arrays, it first sends the length of the array, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class CharArraySender implements Sender<char[]> {
+    private final int length;
+
+    /**
+     * Creates an instance of CharArraySender for dynamic length arrays.
+     */
+    public CharArraySender() {
+        this.length = -1;
+    }
+
+    /**
+     * Creates an instance of CharArraySender for fixed length arrays.
+     *
+     * @param length the length of all arrays to be serialized an deserialized
+     */
+    public CharArraySender(int length) {
+        this.length = length;
+    }
+
+    @Override
+    public char[] read(ObjectInputStream ois) throws IOException {
+        int localLength = length;
+        if (length == -1) {
+            localLength = ois.readInt();
+        }
+        char[] in = new char[localLength];
+        for (int i = 0; i < localLength; i++) {
+            in[i] = ois.readChar();
+        }
+        return in;
+    }
+
+    @Override
+    public void write(char[] out, ObjectOutputStream oos) throws IOException {
+        if (length == -1) {
+            oos.writeInt(out.length);
+        }
+        for (char b : out) {
+            oos.writeChar(b);
+        }
+    }
+}

--- a/src/main/java/parspice/sender/CharArraySender.java
+++ b/src/main/java/parspice/sender/CharArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/CharMatrixSender.java
+++ b/src/main/java/parspice/sender/CharMatrixSender.java
@@ -1,0 +1,67 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for char[][].
+ *
+ * Accepts matrices of fixed dimensions or dynamic dimensions. If fixed dims, the size should
+ * be declared on initialization. If the size is declared, then using matrices of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic matrices, it first sends the dimensions of the matrix, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class CharMatrixSender implements Sender<char[][]> {
+    private final int rows;
+    private final int columns;
+
+    public CharMatrixSender() {
+        rows = -1;
+        columns = -1;
+    }
+
+    /**
+     * Creates an instance of CharMatrix.
+     *
+     * @param rows the number of rows (first dimension) of the matrix.
+     * @param columns the number of columns (second dimension) of the matrix.
+     */
+    public CharMatrixSender(int rows, int columns) {
+        this.rows = rows;
+        this.columns = columns;
+    }
+
+    @Override
+    public char[][] read(ObjectInputStream ois) throws IOException {
+        int localRows = rows;
+        int localColumns = columns;
+        if (rows == -1) {
+            localRows = ois.readInt();
+            localColumns = ois.readInt();
+        }
+        char[][] in = new char[localRows][localColumns];
+        for (int i = 0; i < localRows; i++) {
+            for (int j = 0; j < localColumns; j++) {
+                in[i][j] = ois.readChar();
+            }
+        }
+        return in;
+    }
+
+    @Override
+    public void write(char[][] out, ObjectOutputStream oos) throws IOException {
+        if (rows == -1) {
+            oos.writeInt(out.length);
+            oos.writeInt(out[0].length);
+        }
+        for (char[] row : out) {
+            for (char b : row) {
+                oos.writeChar(b);
+            }
+        }
+    }
+}

--- a/src/main/java/parspice/sender/CharMatrixSender.java
+++ b/src/main/java/parspice/sender/CharMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/CharSender.java
+++ b/src/main/java/parspice/sender/CharSender.java
@@ -1,0 +1,20 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for Character.
+ */
+public class CharSender implements Sender<Character> {
+    @Override
+    public Character read(ObjectInputStream ois) throws IOException {
+        return ois.readChar();
+    }
+
+    @Override
+    public void write(Character out, ObjectOutputStream oos) throws IOException {
+        oos.writeChar(out);
+    }
+}

--- a/src/main/java/parspice/sender/CharSender.java
+++ b/src/main/java/parspice/sender/CharSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/DoubleArraySender.java
+++ b/src/main/java/parspice/sender/DoubleArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/DoubleMatrixSender.java
+++ b/src/main/java/parspice/sender/DoubleMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/DoubleSender.java
+++ b/src/main/java/parspice/sender/DoubleSender.java
@@ -5,7 +5,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 /**
- * Sender implementation for double.
+ * Sender implementation for Double.
  */
 public class DoubleSender implements Sender<Double> {
     @Override

--- a/src/main/java/parspice/sender/DoubleSender.java
+++ b/src/main/java/parspice/sender/DoubleSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/FloatArraySender.java
+++ b/src/main/java/parspice/sender/FloatArraySender.java
@@ -1,0 +1,59 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for float[].
+ *
+ * Accepts arrays of fixed length or dynamic length. If fixed length, the length should
+ * be declared on initialization. If the length is declared, then using arrays of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic arrays, it first sends the length of the array, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class FloatArraySender implements Sender<float[]> {
+    private final int length;
+
+    /**
+     * Creates an instance of FloatArraySender for dynamic length arrays.
+     */
+    public FloatArraySender() {
+        this.length = -1;
+    }
+
+    /**
+     * Creates an instance of FloatArraySender for fixed length arrays.
+     *
+     * @param length the length of all arrays to be serialized an deserialized
+     */
+    public FloatArraySender(int length) {
+        this.length = length;
+    }
+
+    @Override
+    public float[] read(ObjectInputStream ois) throws IOException {
+        int localLength = length;
+        if (length == -1) {
+            localLength = ois.readInt();
+        }
+        float[] in = new float[localLength];
+        for (int i = 0; i < localLength; i++) {
+            in[i] = ois.readFloat();
+        }
+        return in;
+    }
+
+    @Override
+    public void write(float[] out, ObjectOutputStream oos) throws IOException {
+        if (length == -1) {
+            oos.writeInt(out.length);
+        }
+        for (float b : out) {
+            oos.writeFloat(b);
+        }
+    }
+}

--- a/src/main/java/parspice/sender/FloatArraySender.java
+++ b/src/main/java/parspice/sender/FloatArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/FloatMatrixSender.java
+++ b/src/main/java/parspice/sender/FloatMatrixSender.java
@@ -1,0 +1,67 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for float[][].
+ *
+ * Accepts matrices of fixed dimensions or dynamic dimensions. If fixed dims, the size should
+ * be declared on initialization. If the size is declared, then using matrices of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic matrices, it first sends the dimensions of the matrix, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class FloatMatrixSender implements Sender<float[][]> {
+    private final int rows;
+    private final int columns;
+
+    public FloatMatrixSender() {
+        rows = -1;
+        columns = -1;
+    }
+
+    /**
+     * Creates an instance of FloatMatrix.
+     *
+     * @param rows the number of rows (first dimension) of the matrix.
+     * @param columns the number of columns (second dimension) of the matrix.
+     */
+    public FloatMatrixSender(int rows, int columns) {
+        this.rows = rows;
+        this.columns = columns;
+    }
+
+    @Override
+    public float[][] read(ObjectInputStream ois) throws IOException {
+        int localRows = rows;
+        int localColumns = columns;
+        if (rows == -1) {
+            localRows = ois.readInt();
+            localColumns = ois.readInt();
+        }
+        float[][] in = new float[localRows][localColumns];
+        for (int i = 0; i < localRows; i++) {
+            for (int j = 0; j < localColumns; j++) {
+                in[i][j] = ois.readFloat();
+            }
+        }
+        return in;
+    }
+
+    @Override
+    public void write(float[][] out, ObjectOutputStream oos) throws IOException {
+        if (rows == -1) {
+            oos.writeInt(out.length);
+            oos.writeInt(out[0].length);
+        }
+        for (float[] row : out) {
+            for (float b : row) {
+                oos.writeFloat(b);
+            }
+        }
+    }
+}

--- a/src/main/java/parspice/sender/FloatMatrixSender.java
+++ b/src/main/java/parspice/sender/FloatMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/FloatSender.java
+++ b/src/main/java/parspice/sender/FloatSender.java
@@ -1,0 +1,20 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for Float.
+ */
+public class FloatSender implements Sender<Float> {
+    @Override
+    public Float read(ObjectInputStream ois) throws IOException {
+        return ois.readFloat();
+    }
+
+    @Override
+    public void write(Float out, ObjectOutputStream oos) throws IOException {
+        oos.writeFloat(out);
+    }
+}

--- a/src/main/java/parspice/sender/FloatSender.java
+++ b/src/main/java/parspice/sender/FloatSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/IntArraySender.java
+++ b/src/main/java/parspice/sender/IntArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/IntMatrixSender.java
+++ b/src/main/java/parspice/sender/IntMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/IntSender.java
+++ b/src/main/java/parspice/sender/IntSender.java
@@ -5,7 +5,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 /**
- * Sender implementation for int.
+ * Sender implementation for Integer.
  */
 public class IntSender implements Sender<Integer> {
     @Override

--- a/src/main/java/parspice/sender/IntSender.java
+++ b/src/main/java/parspice/sender/IntSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/LongArraySender.java
+++ b/src/main/java/parspice/sender/LongArraySender.java
@@ -1,0 +1,59 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for long[].
+ *
+ * Accepts arrays of fixed length or dynamic length. If fixed length, the length should
+ * be declared on initialization. If the length is declared, then using arrays of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic arrays, it first sends the length of the array, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class LongArraySender implements Sender<long[]> {
+    private final int length;
+
+    /**
+     * Creates an instance of LongArraySender for dynamic length arrays.
+     */
+    public LongArraySender() {
+        this.length = -1;
+    }
+
+    /**
+     * Creates an instance of LongArraySender for fixed length arrays.
+     *
+     * @param length the length of all arrays to be serialized an deserialized
+     */
+    public LongArraySender(int length) {
+        this.length = length;
+    }
+
+    @Override
+    public long[] read(ObjectInputStream ois) throws IOException {
+        int localLength = length;
+        if (length == -1) {
+            localLength = ois.readInt();
+        }
+        long[] in = new long[localLength];
+        for (int i = 0; i < localLength; i++) {
+            in[i] = ois.readLong();
+        }
+        return in;
+    }
+
+    @Override
+    public void write(long[] out, ObjectOutputStream oos) throws IOException {
+        if (length == -1) {
+            oos.writeInt(out.length);
+        }
+        for (long b : out) {
+            oos.writeLong(b);
+        }
+    }
+}

--- a/src/main/java/parspice/sender/LongArraySender.java
+++ b/src/main/java/parspice/sender/LongArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/LongMatrixSender.java
+++ b/src/main/java/parspice/sender/LongMatrixSender.java
@@ -1,0 +1,67 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for long[][].
+ *
+ * Accepts matrices of fixed dimensions or dynamic dimensions. If fixed dims, the size should
+ * be declared on initialization. If the size is declared, then using matrices of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic matrices, it first sends the dimensions of the matrix, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class LongMatrixSender implements Sender<long[][]> {
+    private final int rows;
+    private final int columns;
+
+    public LongMatrixSender() {
+        rows = -1;
+        columns = -1;
+    }
+
+    /**
+     * Creates an instance of LongMatrix.
+     *
+     * @param rows the number of rows (first dimension) of the matrix.
+     * @param columns the number of columns (second dimension) of the matrix.
+     */
+    public LongMatrixSender(int rows, int columns) {
+        this.rows = rows;
+        this.columns = columns;
+    }
+
+    @Override
+    public long[][] read(ObjectInputStream ois) throws IOException {
+        int localRows = rows;
+        int localColumns = columns;
+        if (rows == -1) {
+            localRows = ois.readInt();
+            localColumns = ois.readInt();
+        }
+        long[][] in = new long[localRows][localColumns];
+        for (int i = 0; i < localRows; i++) {
+            for (int j = 0; j < localColumns; j++) {
+                in[i][j] = ois.readLong();
+            }
+        }
+        return in;
+    }
+
+    @Override
+    public void write(long[][] out, ObjectOutputStream oos) throws IOException {
+        if (rows == -1) {
+            oos.writeInt(out.length);
+            oos.writeInt(out[0].length);
+        }
+        for (long[] row : out) {
+            for (long b : row) {
+                oos.writeLong(b);
+            }
+        }
+    }
+}

--- a/src/main/java/parspice/sender/LongMatrixSender.java
+++ b/src/main/java/parspice/sender/LongMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/LongSender.java
+++ b/src/main/java/parspice/sender/LongSender.java
@@ -1,0 +1,20 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for Long.
+ */
+public class LongSender implements Sender<Long> {
+    @Override
+    public Long read(ObjectInputStream ois) throws IOException {
+        return ois.readLong();
+    }
+
+    @Override
+    public void write(Long out, ObjectOutputStream oos) throws IOException {
+        oos.writeLong(out);
+    }
+}

--- a/src/main/java/parspice/sender/LongSender.java
+++ b/src/main/java/parspice/sender/LongSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/ShortArraySender.java
+++ b/src/main/java/parspice/sender/ShortArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/ShortArraySender.java
+++ b/src/main/java/parspice/sender/ShortArraySender.java
@@ -1,0 +1,59 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for short[].
+ *
+ * Accepts arrays of fixed length or dynamic length. If fixed length, the length should
+ * be declared on initialization. If the length is declared, then using arrays of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic arrays, it first sends the length of the array, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class ShortArraySender implements Sender<short[]> {
+    private final int length;
+
+    /**
+     * Creates an instance of ShortArraySender for dynamic length arrays.
+     */
+    public ShortArraySender() {
+        this.length = -1;
+    }
+
+    /**
+     * Creates an instance of ShortArraySender for fixed length arrays.
+     *
+     * @param length the length of all arrays to be serialized an deserialized
+     */
+    public ShortArraySender(int length) {
+        this.length = length;
+    }
+
+    @Override
+    public short[] read(ObjectInputStream ois) throws IOException {
+        int localLength = length;
+        if (length == -1) {
+            localLength = ois.readInt();
+        }
+        short[] in = new short[localLength];
+        for (int i = 0; i < localLength; i++) {
+            in[i] = ois.readShort();
+        }
+        return in;
+    }
+
+    @Override
+    public void write(short[] out, ObjectOutputStream oos) throws IOException {
+        if (length == -1) {
+            oos.writeInt(out.length);
+        }
+        for (short b : out) {
+            oos.writeShort(b);
+        }
+    }
+}

--- a/src/main/java/parspice/sender/ShortMatrixSender.java
+++ b/src/main/java/parspice/sender/ShortMatrixSender.java
@@ -1,0 +1,67 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for short[][].
+ *
+ * Accepts matrices of fixed dimensions or dynamic dimensions. If fixed dims, the size should
+ * be declared on initialization. If the size is declared, then using matrices of
+ * any other size is undefined behavior, and may or may not cause a runtime error.
+ *
+ * When sending dynamic matrices, it first sends the dimensions of the matrix, increasing
+ * network usage slightly. It doesn't matter significantly for more tasks, but
+ * remember to specify the lengths for optimal performance.
+ */
+public class ShortMatrixSender implements Sender<short[][]> {
+    private final int rows;
+    private final int columns;
+
+    public ShortMatrixSender() {
+        rows = -1;
+        columns = -1;
+    }
+
+    /**
+     * Creates an instance of ShortMatrix.
+     *
+     * @param rows the number of rows (first dimension) of the matrix.
+     * @param columns the number of columns (second dimension) of the matrix.
+     */
+    public ShortMatrixSender(int rows, int columns) {
+        this.rows = rows;
+        this.columns = columns;
+    }
+
+    @Override
+    public short[][] read(ObjectInputStream ois) throws IOException {
+        int localRows = rows;
+        int localColumns = columns;
+        if (rows == -1) {
+            localRows = ois.readInt();
+            localColumns = ois.readInt();
+        }
+        short[][] in = new short[localRows][localColumns];
+        for (int i = 0; i < localRows; i++) {
+            for (int j = 0; j < localColumns; j++) {
+                in[i][j] = ois.readShort();
+            }
+        }
+        return in;
+    }
+
+    @Override
+    public void write(short[][] out, ObjectOutputStream oos) throws IOException {
+        if (rows == -1) {
+            oos.writeInt(out.length);
+            oos.writeInt(out[0].length);
+        }
+        for (short[] row : out) {
+            for (short b : row) {
+                oos.writeShort(b);
+            }
+        }
+    }
+}

--- a/src/main/java/parspice/sender/ShortMatrixSender.java
+++ b/src/main/java/parspice/sender/ShortMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/ShortSender.java
+++ b/src/main/java/parspice/sender/ShortSender.java
@@ -1,0 +1,20 @@
+package parspice.sender;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Sender implementation for Short.
+ */
+public class ShortSender implements Sender<Short> {
+    @Override
+    public Short read(ObjectInputStream ois) throws IOException {
+        return ois.readShort();
+    }
+
+    @Override
+    public void write(Short out, ObjectOutputStream oos) throws IOException {
+        oos.writeShort(out);
+    }
+}

--- a/src/main/java/parspice/sender/ShortSender.java
+++ b/src/main/java/parspice/sender/ShortSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/StringArraySender.java
+++ b/src/main/java/parspice/sender/StringArraySender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/StringMatrixSender.java
+++ b/src/main/java/parspice/sender/StringMatrixSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/main/java/parspice/sender/StringSender.java
+++ b/src/main/java/parspice/sender/StringSender.java
@@ -1,3 +1,6 @@
+// THIS FILE WAS GENERATED. DO NOT EDIT IT DIRECTLY.
+// See `src/gen/README.md` for details.
+
 package parspice.sender;
 
 import java.io.IOException;

--- a/src/test/java/parspiceTest/ParSPICEInstance.java
+++ b/src/test/java/parspiceTest/ParSPICEInstance.java
@@ -1,4 +1,6 @@
-package parspice;
+package parspiceTest;
+
+import parspice.ParSPICE;
 
 import java.io.IOException;
 

--- a/src/test/java/parspiceTest/sender/TestBooleanArraySender.java
+++ b/src/test/java/parspiceTest/sender/TestBooleanArraySender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.DoubleArraySender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.BooleanArraySender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,19 +15,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestDoubleArraySender extends OWorker<double[]> {
-    ArrayList<double[]> parResults;
+public class TestBooleanArraySender extends OWorker<boolean[]> {
+    ArrayList<boolean[]> parResults;
     int numIterations = 10;
 
-    public TestDoubleArraySender() {
-        super(new DoubleArraySender());
+    public TestBooleanArraySender() {
+        super(new BooleanArraySender());
     }
 
     @Override
-    public double[] task(int i) throws Exception {
+    public boolean[] task(int i) throws Exception {
         System.out.println(i);
-        double[] results = {1.1,2.2};
-        return results;
+        boolean[] re = {false,true};
+        return re;
     }
 
     @Test
@@ -35,7 +35,7 @@ public class TestDoubleArraySender extends OWorker<double[]> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestDoubleArraySender(),
+                    new TestBooleanArraySender(),
                     numIterations,
                     2
             );
@@ -45,11 +45,13 @@ public class TestDoubleArraySender extends OWorker<double[]> {
 
     @Test
     public void testCorrectness() {
-        List<double[]> directResults = new ArrayList<double[]>(numIterations);
+        List<boolean[]> directResults = new ArrayList<boolean[]>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            double[] x = {1.1,2.2};
+            boolean[] x = {false,true};
             directResults.add(x);
         }
+
+
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }
 }

--- a/src/test/java/parspiceTest/sender/TestBooleanMatrixSender.java
+++ b/src/test/java/parspiceTest/sender/TestBooleanMatrixSender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.DoubleMatrixSender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.BooleanMatrixSender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,19 +15,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestDoubleMatrixSender extends OWorker<double[][]> {
-    ArrayList<double[][]> parResults;
+public class TestBooleanMatrixSender extends OWorker<boolean[][]> {
+    ArrayList<boolean[][]> parResults;
     int numIterations = 10;
 
-    public TestDoubleMatrixSender() {
-        super(new DoubleMatrixSender());
+    public TestBooleanMatrixSender() {
+        super(new BooleanMatrixSender());
     }
 
     @Override
-    public double[][] task(int i) throws Exception {
+    public boolean[][] task(int i) throws Exception {
         System.out.println(i);
-        double[][] results = {{1.1,2.2},{1.1,2.2}};
-        return results;
+        boolean[][] re = {{false,true},{false,true}};
+        return re;
     }
 
     @Test
@@ -35,7 +35,7 @@ public class TestDoubleMatrixSender extends OWorker<double[][]> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestDoubleMatrixSender(),
+                    new TestBooleanMatrixSender(),
                     numIterations,
                     2
             );
@@ -45,9 +45,9 @@ public class TestDoubleMatrixSender extends OWorker<double[][]> {
 
     @Test
     public void testCorrectness() {
-        List<double[][]> directResults = new ArrayList<double[][]>(numIterations);
+        List<boolean[][]> directResults = new ArrayList<boolean[][]>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            double[][] x = {{1.1,2.2},{1.1,2.2}};
+            boolean[][] x = {{false,true},{false,true}};
             directResults.add(x);
         }
 

--- a/src/test/java/parspiceTest/sender/TestBooleanSender.java
+++ b/src/test/java/parspiceTest/sender/TestBooleanSender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.StringArraySender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.BooleanSender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,19 +15,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestStringArraySender extends OWorker<String[]> {
-    ArrayList<String[]> parResults;
+public class TestBooleanSender extends OWorker<Boolean>  {
+    ArrayList<Boolean> parResults;
     int numIterations = 10;
 
-    public TestStringArraySender() {
-        super(new StringArraySender());
+    public TestBooleanSender() {
+        super(new BooleanSender());
     }
 
     @Override
-    public String[] task(int i) throws Exception {
-        System.out.println(i);
-        String[] results = {"Test","Correct"};
-        return results;
+    public Boolean task(int i) throws Exception {
+        return true;
     }
 
     @Test
@@ -35,20 +33,18 @@ public class TestStringArraySender extends OWorker<String[]> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestStringArraySender(),
+                    new TestBooleanSender(),
                     numIterations,
                     2
             );
         });
-
     }
 
     @Test
     public void testCorrectness() {
-        List<String[]> directResults = new ArrayList<String[]>(numIterations);
+        List<Boolean> directResults = new ArrayList<>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            String[] x = {"Test","Correct"};
-            directResults.add(x);
+            directResults.add(true);
         }
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }

--- a/src/test/java/parspiceTest/sender/TestDoubleArraySender.java
+++ b/src/test/java/parspiceTest/sender/TestDoubleArraySender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.StringMatrixSender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.DoubleArraySender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,18 +15,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestStringMatrixSender extends OWorker<String[][]> {
-    ArrayList<String[][]> parResults;
+public class TestDoubleArraySender extends OWorker<double[]> {
+    ArrayList<double[]> parResults;
     int numIterations = 10;
 
-    public TestStringMatrixSender() {
-        super(new StringMatrixSender());
+    public TestDoubleArraySender() {
+        super(new DoubleArraySender());
     }
 
     @Override
-    public String[][] task(int i) throws Exception {
+    public double[] task(int i) throws Exception {
         System.out.println(i);
-        String[][] results = {{"Test","Correct"},{"Test","Correct"}};
+        double[] results = {1.1,2.2};
         return results;
     }
 
@@ -35,7 +35,7 @@ public class TestStringMatrixSender extends OWorker<String[][]> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestStringMatrixSender(),
+                    new TestDoubleArraySender(),
                     numIterations,
                     2
             );
@@ -45,12 +45,11 @@ public class TestStringMatrixSender extends OWorker<String[][]> {
 
     @Test
     public void testCorrectness() {
-        List<String[][]> directResults = new ArrayList<String[][]>(numIterations);
+        List<double[]> directResults = new ArrayList<double[]>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            String[][] x = {{"Test","Correct"},{"Test","Correct"}};
+            double[] x = {1.1,2.2};
             directResults.add(x);
         }
-
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }
 }

--- a/src/test/java/parspiceTest/sender/TestDoubleMatrixSender.java
+++ b/src/test/java/parspiceTest/sender/TestDoubleMatrixSender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.IntMatrixSender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.DoubleMatrixSender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,18 +15,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestIntMatrixSender extends OWorker<int[][]> {
-    ArrayList<int[][]> parResults;
+public class TestDoubleMatrixSender extends OWorker<double[][]> {
+    ArrayList<double[][]> parResults;
     int numIterations = 10;
 
-    public TestIntMatrixSender() {
-        super(new IntMatrixSender());
+    public TestDoubleMatrixSender() {
+        super(new DoubleMatrixSender());
     }
 
     @Override
-    public int[][] task(int i) throws Exception {
+    public double[][] task(int i) throws Exception {
         System.out.println(i);
-        int[][] results = {{1,2},{1,2}};
+        double[][] results = {{1.1,2.2},{1.1,2.2}};
         return results;
     }
 
@@ -35,7 +35,7 @@ public class TestIntMatrixSender extends OWorker<int[][]> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestIntMatrixSender(),
+                    new TestDoubleMatrixSender(),
                     numIterations,
                     2
             );
@@ -45,9 +45,9 @@ public class TestIntMatrixSender extends OWorker<int[][]> {
 
     @Test
     public void testCorrectness() {
-        List<int[][]> directResults = new ArrayList<int[][]>(numIterations);
+        List<double[][]> directResults = new ArrayList<double[][]>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            int[][] x = {{1,2},{1,2}};
+            double[][] x = {{1.1,2.2},{1.1,2.2}};
             directResults.add(x);
         }
 

--- a/src/test/java/parspiceTest/sender/TestDoubleSender.java
+++ b/src/test/java/parspiceTest/sender/TestDoubleSender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.BooleanMatrixSender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.DoubleSender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,19 +15,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestBooleanMatrixSender extends OWorker<boolean[][]> {
-    ArrayList<boolean[][]> parResults;
+public class TestDoubleSender extends OWorker<Double> {
+    ArrayList<Double> parResults;
     int numIterations = 10;
 
-    public TestBooleanMatrixSender() {
-        super(new BooleanMatrixSender());
+    public TestDoubleSender() {
+        super(new DoubleSender());
     }
 
     @Override
-    public boolean[][] task(int i) throws Exception {
-        System.out.println(i);
-        boolean[][] re = {{false,true},{false,true}};
-        return re;
+    public Double task(int i) throws Exception {
+        return i/2.;
     }
 
     @Test
@@ -35,22 +33,19 @@ public class TestBooleanMatrixSender extends OWorker<boolean[][]> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestBooleanMatrixSender(),
+                    new TestDoubleSender(),
                     numIterations,
                     2
             );
         });
-
     }
 
     @Test
     public void testCorrectness() {
-        List<boolean[][]> directResults = new ArrayList<boolean[][]>(numIterations);
+        List<Double> directResults = new ArrayList<>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            boolean[][] x = {{false,true},{false,true}};
-            directResults.add(x);
+            directResults.add(i/2.);
         }
-
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }
 }

--- a/src/test/java/parspiceTest/sender/TestIntArraySender.java
+++ b/src/test/java/parspiceTest/sender/TestIntArraySender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.BooleanSender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.IntArraySender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,17 +15,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestBooleanSender extends OWorker<Boolean>  {
-    ArrayList<Boolean> parResults;
+public class TestIntArraySender extends OWorker<int[]> {
+    ArrayList<int[]> parResults;
     int numIterations = 10;
 
-    public TestBooleanSender() {
-        super(new BooleanSender());
+    public TestIntArraySender() {
+        super(new IntArraySender());
     }
 
     @Override
-    public Boolean task(int i) throws Exception {
-        return true;
+    public int[] task(int i) throws Exception {
+        System.out.println(i);
+        int[] results = {1,2};
+        return results;
     }
 
     @Test
@@ -33,18 +35,20 @@ public class TestBooleanSender extends OWorker<Boolean>  {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestBooleanSender(),
+                    new TestIntArraySender(),
                     numIterations,
                     2
             );
         });
+
     }
 
     @Test
     public void testCorrectness() {
-        List<Boolean> directResults = new ArrayList<>(numIterations);
+        List<int[]> directResults = new ArrayList<int[]>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            directResults.add(true);
+            int[] x = {1,2};
+            directResults.add(x);
         }
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }

--- a/src/test/java/parspiceTest/sender/TestIntMatrixSender.java
+++ b/src/test/java/parspiceTest/sender/TestIntMatrixSender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.IntSender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.IntMatrixSender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,17 +15,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestIntSender extends OWorker<Integer> {
-    ArrayList<Integer> parResults;
+public class TestIntMatrixSender extends OWorker<int[][]> {
+    ArrayList<int[][]> parResults;
     int numIterations = 10;
 
-    public TestIntSender() {
-        super(new IntSender());
+    public TestIntMatrixSender() {
+        super(new IntMatrixSender());
     }
 
     @Override
-    public Integer task(int i) throws Exception {
-        return i;
+    public int[][] task(int i) throws Exception {
+        System.out.println(i);
+        int[][] results = {{1,2},{1,2}};
+        return results;
     }
 
     @Test
@@ -33,19 +35,22 @@ public class TestIntSender extends OWorker<Integer> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestIntSender(),
+                    new TestIntMatrixSender(),
                     numIterations,
                     2
             );
         });
+
     }
 
     @Test
     public void testCorrectness() {
-        List<Integer> directResults = new ArrayList<Integer>(numIterations);
+        List<int[][]> directResults = new ArrayList<int[][]>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            directResults.add(i);
+            int[][] x = {{1,2},{1,2}};
+            directResults.add(x);
         }
+
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }
 }

--- a/src/test/java/parspiceTest/sender/TestIntSender.java
+++ b/src/test/java/parspiceTest/sender/TestIntSender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.DoubleSender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.IntSender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,17 +15,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestDoubleSender extends OWorker<Double> {
-    ArrayList<Double> parResults;
+public class TestIntSender extends OWorker<Integer> {
+    ArrayList<Integer> parResults;
     int numIterations = 10;
 
-    public TestDoubleSender() {
-        super(new DoubleSender());
+    public TestIntSender() {
+        super(new IntSender());
     }
 
     @Override
-    public Double task(int i) throws Exception {
-        return i/2.;
+    public Integer task(int i) throws Exception {
+        return i;
     }
 
     @Test
@@ -33,7 +33,7 @@ public class TestDoubleSender extends OWorker<Double> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestDoubleSender(),
+                    new TestIntSender(),
                     numIterations,
                     2
             );
@@ -42,9 +42,9 @@ public class TestDoubleSender extends OWorker<Double> {
 
     @Test
     public void testCorrectness() {
-        List<Double> directResults = new ArrayList<>(numIterations);
+        List<Integer> directResults = new ArrayList<Integer>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            directResults.add(i/2.);
+            directResults.add(i);
         }
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }

--- a/src/test/java/parspiceTest/sender/TestStringArraySender.java
+++ b/src/test/java/parspiceTest/sender/TestStringArraySender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.StringSender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.StringArraySender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,17 +15,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestStringSender extends OWorker<String> {
-    ArrayList<String> parResults;
+public class TestStringArraySender extends OWorker<String[]> {
+    ArrayList<String[]> parResults;
     int numIterations = 10;
 
-    public TestStringSender() {
-        super(new StringSender());
+    public TestStringArraySender() {
+        super(new StringArraySender());
     }
 
     @Override
-    public String task(int i) throws Exception {
-        return "Test";
+    public String[] task(int i) throws Exception {
+        System.out.println(i);
+        String[] results = {"Test","Correct"};
+        return results;
     }
 
     @Test
@@ -33,18 +35,20 @@ public class TestStringSender extends OWorker<String> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestStringSender(),
+                    new TestStringArraySender(),
                     numIterations,
                     2
             );
         });
+
     }
 
     @Test
     public void testCorrectness() {
-        List<String> directResults = new ArrayList<String>(numIterations);
+        List<String[]> directResults = new ArrayList<String[]>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            directResults.add("Test");
+            String[] x = {"Test","Correct"};
+            directResults.add(x);
         }
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }

--- a/src/test/java/parspiceTest/sender/TestStringMatrixSender.java
+++ b/src/test/java/parspiceTest/sender/TestStringMatrixSender.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.BooleanArraySender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.StringMatrixSender;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -15,19 +15,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestBooleanArraySender extends OWorker<boolean[]> {
-    ArrayList<boolean[]> parResults;
+public class TestStringMatrixSender extends OWorker<String[][]> {
+    ArrayList<String[][]> parResults;
     int numIterations = 10;
 
-    public TestBooleanArraySender() {
-        super(new BooleanArraySender());
+    public TestStringMatrixSender() {
+        super(new StringMatrixSender());
     }
 
     @Override
-    public boolean[] task(int i) throws Exception {
+    public String[][] task(int i) throws Exception {
         System.out.println(i);
-        boolean[] re = {false,true};
-        return re;
+        String[][] results = {{"Test","Correct"},{"Test","Correct"}};
+        return results;
     }
 
     @Test
@@ -35,7 +35,7 @@ public class TestBooleanArraySender extends OWorker<boolean[]> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestBooleanArraySender(),
+                    new TestStringMatrixSender(),
                     numIterations,
                     2
             );
@@ -45,12 +45,11 @@ public class TestBooleanArraySender extends OWorker<boolean[]> {
 
     @Test
     public void testCorrectness() {
-        List<boolean[]> directResults = new ArrayList<boolean[]>(numIterations);
+        List<String[][]> directResults = new ArrayList<String[][]>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            boolean[] x = {false,true};
+            String[][] x = {{"Test","Correct"},{"Test","Correct"}};
             directResults.add(x);
         }
-
 
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }

--- a/src/test/java/parspiceTest/sender/TestStringSender.java
+++ b/src/test/java/parspiceTest/sender/TestStringSender.java
@@ -1,13 +1,9 @@
-package parspice.testGeneral;
+package parspiceTest.sender;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.IntSender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.StringSender;
 import parspice.worker.OWorker;
-
-
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,25 +11,21 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestSetup extends OWorker<Integer> {
-    ArrayList<Integer> parResults;
+public class TestStringSender extends OWorker<String> {
+    ArrayList<String> parResults;
     int numIterations = 10;
 
-    private static int n = 0;
-
-    public TestSetup() {
-        super(new IntSender());
+    public TestStringSender() {
+        super(new StringSender());
     }
 
     @Override
-    public void setup() throws Exception {
-        n = 2;
-    }
-
-    @Override
-    public Integer task(int i) throws Exception {
-        return n + i;
+    public String task(int i) throws Exception {
+        return "Test";
     }
 
     @Test
@@ -41,7 +33,7 @@ public class TestSetup extends OWorker<Integer> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestSetup(),
+                    new TestStringSender(),
                     numIterations,
                     2
             );
@@ -50,9 +42,9 @@ public class TestSetup extends OWorker<Integer> {
 
     @Test
     public void testCorrectness() {
-        List<Integer> directResults = new ArrayList<>(numIterations);
+        List<String> directResults = new ArrayList<String>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            directResults.add(i + 2);
+            directResults.add("Test");
         }
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }

--- a/src/test/java/parspiceTest/worker/TestAutoWorker.java
+++ b/src/test/java/parspiceTest/worker/TestAutoWorker.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.worker;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
+import parspiceTest.ParSPICEInstance;
 import parspice.worker.AutoWorker;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/src/test/java/parspiceTest/worker/TestIOWorker.java
+++ b/src/test/java/parspiceTest/worker/TestIOWorker.java
@@ -1,15 +1,13 @@
-package parspice.testGeneral;
+package parspiceTest.worker;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
+import parspiceTest.ParSPICEInstance;
 import parspice.sender.IntSender;
 import parspice.worker.IOWorker;
-import parspice.worker.OWorker;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;

--- a/src/test/java/parspiceTest/worker/TestIWorker.java
+++ b/src/test/java/parspiceTest/worker/TestIWorker.java
@@ -1,8 +1,8 @@
-package parspice.testGeneral;
+package parspiceTest.worker;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
+import parspiceTest.ParSPICEInstance;
 import parspice.sender.IntSender;
 import parspice.worker.IWorker;
 

--- a/src/test/java/parspiceTest/worker/TestSetup.java
+++ b/src/test/java/parspiceTest/worker/TestSetup.java
@@ -1,8 +1,12 @@
-package parspice.testGeneral;
+package parspiceTest.worker;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
-import parspice.ParSPICEInstance;
-import parspice.sender.IntArraySender;
+import parspiceTest.ParSPICEInstance;
+import parspice.sender.IntSender;
+
+
+import org.junit.jupiter.api.Test;
 import parspice.worker.OWorker;
 
 import java.util.ArrayList;
@@ -11,23 +15,25 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeAll;
-
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestIntArraySender extends OWorker<int[]> {
-    ArrayList<int[]> parResults;
+public class TestSetup extends OWorker<Integer> {
+    ArrayList<Integer> parResults;
     int numIterations = 10;
 
-    public TestIntArraySender() {
-        super(new IntArraySender());
+    private static int n = 0;
+
+    public TestSetup() {
+        super(new IntSender());
     }
 
     @Override
-    public int[] task(int i) throws Exception {
-        System.out.println(i);
-        int[] results = {1,2};
-        return results;
+    public void setup() throws Exception {
+        n = 2;
+    }
+
+    @Override
+    public Integer task(int i) throws Exception {
+        return n + i;
     }
 
     @Test
@@ -35,20 +41,18 @@ public class TestIntArraySender extends OWorker<int[]> {
     public void testRun() {
         assertDoesNotThrow(() -> {
             parResults = ParSPICEInstance.par.run(
-                    new TestIntArraySender(),
+                    new TestSetup(),
                     numIterations,
                     2
             );
         });
-
     }
 
     @Test
     public void testCorrectness() {
-        List<int[]> directResults = new ArrayList<int[]>(numIterations);
+        List<Integer> directResults = new ArrayList<>(numIterations);
         for (int i = 0; i < numIterations; i++) {
-            int[] x = {1,2};
-            directResults.add(x);
+            directResults.add(i + 2);
         }
         assertArrayEquals(parResults.toArray(), directResults.toArray());
     }


### PR DESCRIPTION
This PR adds Senders for all Object-wrapped primitives, arrays of primitives, and nested arrays of primitives. Since the JVM doesn't allow generic type arguments to be primitive, the only way to consolidate the logic is to use code generation.